### PR TITLE
feat: add an observer for next valid id and a method in request to allow end user to set it

### DIFF
--- a/InterReact/Core/Request.cs
+++ b/InterReact/Core/Request.cs
@@ -45,6 +45,7 @@ public sealed class Request
     /// Returns successive unique ids which are used to uniquely identify requests and orders.
     /// </summary>
     public int GetNextId() => Interlocked.Increment(ref NextIdValue);
+    public int SetNextId(int nextIdValue) => Interlocked.Exchange(ref NextIdValue, nextIdValue);
     private int NextIdValue;
 
     //////////////////////////////////////////////////////////////////////////////////////////////

--- a/InterReact/Services/NextValidIdObservable.cs
+++ b/InterReact/Services/NextValidIdObservable.cs
@@ -1,0 +1,17 @@
+﻿using System.Reactive.Linq;
+
+namespace InterReact;
+
+public partial class Service
+{
+    /// <summary>
+    /// An observable which emits the current time, then completes.
+    /// </summary>
+    public IObservable<int> NextValidIdObservable { get; }
+
+    private IObservable<int> CreateNextValidIdObservable() =>
+        Response
+            .ToObservableSingle<NextId>(() => Request.RequestIds(-1))
+            .Select(m => m.Id)
+            .ShareSource();
+}

--- a/InterReact/Services/Services.cs
+++ b/InterReact/Services/Services.cs
@@ -13,5 +13,6 @@ public sealed partial class Service
         AccountUpdatesObservable = CreateAccountUpdatesObservable();
         PositionsObservable = CreatePositionsObservable();
         AccountSummaryObservable = CreateAccountSummaryObservable();
+        NextValidIdObservable = CreateNextValidIdObservable();
     }
 }


### PR DESCRIPTION
Was getting duplicate orderId's after restarting app (was not correctly setting next valid id). Let me know if there is a better way to go. I can update the docs and show how to properly use it if you want.